### PR TITLE
Add support for ansible 2.7.2 ansible_selinux facts

### DIFF
--- a/templates/motd.j2
+++ b/templates/motd.j2
@@ -3,7 +3,7 @@
   {{ ansible_distribution }} {{ ansible_distribution_version }} {{ ansible_architecture }}
   
   fqdn: {{ inventory_hostname }} ({{ ansible_default_ipv4.address }})
-  selinux: {{ ansible_selinux.config_mode }}
+  selinux: {{ ansible_selinux.config_mode || ansible_selinux.status }}
   memory: {{ ansible_memtotal_mb }}
   cpu count: {{ ansible_processor_count }} cores: {{ ansible_processor_cores }} tpc: {{ ansible_processor_threads_per_core }} vcpus: {{ ansible_processor_vcpus }}
 

--- a/templates/motd.j2
+++ b/templates/motd.j2
@@ -3,7 +3,7 @@
   {{ ansible_distribution }} {{ ansible_distribution_version }} {{ ansible_architecture }}
   
   fqdn: {{ inventory_hostname }} ({{ ansible_default_ipv4.address }})
-  selinux: {{ ansible_selinux.config_mode || ansible_selinux.status }}
+  selinux: {{ if ansible_selinux.config_mode is | default(ansible_selinux.status) }}
   memory: {{ ansible_memtotal_mb }}
   cpu count: {{ ansible_processor_count }} cores: {{ ansible_processor_cores }} tpc: {{ ansible_processor_threads_per_core }} vcpus: {{ ansible_processor_vcpus }}
 

--- a/templates/motd.j2
+++ b/templates/motd.j2
@@ -3,7 +3,7 @@
   {{ ansible_distribution }} {{ ansible_distribution_version }} {{ ansible_architecture }}
   
   fqdn: {{ inventory_hostname }} ({{ ansible_default_ipv4.address }})
-  selinux: {{ ansible_selinux.config_mode | default(ansible_selinux.status) }}
+  selinux: {{ ansible_selinux.status | default(ansible_selinux.config_mode) }}
   memory: {{ ansible_memtotal_mb }}
   cpu count: {{ ansible_processor_count }} cores: {{ ansible_processor_cores }} tpc: {{ ansible_processor_threads_per_core }} vcpus: {{ ansible_processor_vcpus }}
 

--- a/templates/motd.j2
+++ b/templates/motd.j2
@@ -3,7 +3,7 @@
   {{ ansible_distribution }} {{ ansible_distribution_version }} {{ ansible_architecture }}
   
   fqdn: {{ inventory_hostname }} ({{ ansible_default_ipv4.address }})
-  selinux: {{ if ansible_selinux.config_mode is | default(ansible_selinux.status) }}
+  selinux: {{ ansible_selinux.config_mode | default(ansible_selinux.status) }}
   memory: {{ ansible_memtotal_mb }}
   cpu count: {{ ansible_processor_count }} cores: {{ ansible_processor_cores }} tpc: {{ ansible_processor_threads_per_core }} vcpus: {{ ansible_processor_vcpus }}
 


### PR DESCRIPTION
When running the role with ansible 2.7.2 I get a dict error for ansible_selinux.
Seems like the fact has changed. 
```
TASK [opuk.common : set motd] *************************************************************************************************************************************************************************************
fatal: [burken]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: 'dict object' has no attribute 'config_mode'"}


[moss@lappatop lab.moogle.cloud]$ ansible -m setup  -i inventory labhosts | grep -A 3 ansible_selinux
        "ansible_selinux": {
            "status": "disabled"
        }, 


[moss@lappatop lab.moogle.cloud]$ ansible --version
ansible 2.7.2
```

This will first try the new ansible_selinux.status but default to the old one. 